### PR TITLE
✨ 토큰 기반의 카카오 로그인 api를 개발한다.

### DIFF
--- a/back/src/main/java/crappyUnivLife/timeMachineLetter/api/MemberApiController.java
+++ b/back/src/main/java/crappyUnivLife/timeMachineLetter/api/MemberApiController.java
@@ -6,6 +6,7 @@ import crappyUnivLife.timeMachineLetter.dto.DecryptionLetterRequest;
 import crappyUnivLife.timeMachineLetter.dto.LetterListResponse;
 import crappyUnivLife.timeMachineLetter.dto.LetterReadResponse;
 import crappyUnivLife.timeMachineLetter.dto.ReceivePostListResponse;
+import crappyUnivLife.timeMachineLetter.security.kakao.KakaoOAuth2;
 import crappyUnivLife.timeMachineLetter.service.LetterService;
 import crappyUnivLife.timeMachineLetter.service.MemberService;
 import lombok.Data;
@@ -21,11 +22,18 @@ public class MemberApiController {
 
     private final MemberService memberService;
     private final LetterService letterService;
+    private final KakaoOAuth2 kakaoOAuth2;
 
 
     @PostMapping("/user/login")
-    public LetterListResponse loginRequest(@RequestBody String authorizedCode, HttpSession session) {
-        return memberService.kakaoLogin(authorizedCode, session);
+    public LetterListResponse kakaoCodeLoginRequest(@RequestBody String authorizedCode, HttpSession session) {
+        String accessToken = kakaoOAuth2.getAccessToken(authorizedCode);
+        return memberService.kakaoLogin(accessToken, session);
+    }
+
+    @PostMapping("/user/token-login")
+    public LetterListResponse kakaoTokenLoginRequest(@RequestBody String accessToken, HttpSession session) {
+        return memberService.kakaoLogin(accessToken, session);
     }
 
     @PostMapping("/user/logout")

--- a/back/src/main/java/crappyUnivLife/timeMachineLetter/api/MemberApiController.java
+++ b/back/src/main/java/crappyUnivLife/timeMachineLetter/api/MemberApiController.java
@@ -1,7 +1,6 @@
 package crappyUnivLife.timeMachineLetter.api;
 
 import crappyUnivLife.timeMachineLetter.domain.Letter;
-import crappyUnivLife.timeMachineLetter.domain.Member;
 import crappyUnivLife.timeMachineLetter.dto.DecryptionLetterRequest;
 import crappyUnivLife.timeMachineLetter.dto.LetterListResponse;
 import crappyUnivLife.timeMachineLetter.dto.LetterReadResponse;
@@ -9,12 +8,10 @@ import crappyUnivLife.timeMachineLetter.dto.ReceivePostListResponse;
 import crappyUnivLife.timeMachineLetter.security.kakao.KakaoOAuth2;
 import crappyUnivLife.timeMachineLetter.service.LetterService;
 import crappyUnivLife.timeMachineLetter.service.MemberService;
-import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpSession;
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor

--- a/back/src/main/java/crappyUnivLife/timeMachineLetter/security/kakao/KakaoOAuth2.java
+++ b/back/src/main/java/crappyUnivLife/timeMachineLetter/security/kakao/KakaoOAuth2.java
@@ -1,7 +1,6 @@
 package crappyUnivLife.timeMachineLetter.security.kakao;
 
 import crappyUnivLife.timeMachineLetter.domain.Member;
-import crappyUnivLife.timeMachineLetter.dto.KakaoUserInfo;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
@@ -10,7 +9,6 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
-import java.io.IOException;
 
 @Service
 public class KakaoOAuth2 {

--- a/back/src/main/java/crappyUnivLife/timeMachineLetter/service/MemberService.java
+++ b/back/src/main/java/crappyUnivLife/timeMachineLetter/service/MemberService.java
@@ -1,8 +1,6 @@
 package crappyUnivLife.timeMachineLetter.service;
 
-import crappyUnivLife.timeMachineLetter.domain.Letter;
 import crappyUnivLife.timeMachineLetter.domain.Member;
-import crappyUnivLife.timeMachineLetter.dto.KakaoUserInfo;
 import crappyUnivLife.timeMachineLetter.dto.LetterListResponse;
 import crappyUnivLife.timeMachineLetter.repository.MemberRepository;
 import crappyUnivLife.timeMachineLetter.security.kakao.KakaoOAuth2;
@@ -12,8 +10,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.servlet.http.HttpSession;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 @Service

--- a/back/src/main/java/crappyUnivLife/timeMachineLetter/service/MemberService.java
+++ b/back/src/main/java/crappyUnivLife/timeMachineLetter/service/MemberService.java
@@ -26,8 +26,7 @@ public class MemberService {
     private final LetterService letterService;
     private final KakaoOAuth2 kakaoOAuth2;
 
-    public LetterListResponse kakaoLogin(String authorizedCode, HttpSession session) {
-        String accessToken = kakaoOAuth2.getAccessToken(authorizedCode);
+    public LetterListResponse kakaoLogin(String accessToken, HttpSession session) {
         Member member = kakaoOAuth2.getUserInfoByAccessToken(accessToken);
 
         //기존에 없던 회원이면 회원가입 - DB에 저장


### PR DESCRIPTION
기존에 front 와 작업할 때, 인가코드를 주고 받는 형식으로 카카오 로그인 api를 구현했는데,

application 단에서는, sdk 를 활용해서 인가토큰을 바로 받는 방법이 있으며,
이 방법이 사용자 경험에 있어서 깔끔한 로그인 환경을 제공한다고 생각됩니다.
- application에서 rest api를 통해 redirect를 사용하면, web view를 띄워서 하는 과정이 있음.

<hr>

기존 코드의 경우, 카카오 인가코드를 기반으로 한 로그인 로직에 의존적이라서, 유연성을 위해 컨트롤러와 서비스 계층 구조를 변경했습니다.

close #61 