### PR TITLE
:white_check_mark: LetterList 테스트코드 동작 로직 변경

### DIFF
--- a/front/src/__mocks__/react-redux.js
+++ b/front/src/__mocks__/react-redux.js
@@ -1,2 +1,0 @@
-export const useSelector = jest.fn();
-export const useDispatch = jest.fn();

--- a/front/src/__test__/components/LetterList/LetterList.test.js
+++ b/front/src/__test__/components/LetterList/LetterList.test.js
@@ -1,28 +1,22 @@
-import { useDispatch, useSelector } from 'react-redux';
 import { render, screen, fireEvent } from '../../../../test.utils';
 import LetterList from '../../../components/LetterList/LetterList';
 import { dummyLetter } from '../../../fixtures/dummyLetter';
 
-jest.mock('react-redux');
-
 describe('LetterList 테스트코드', () => {
   beforeEach(() => {
-    const dispatch = jest.fn();
-    useDispatch.mockImplementation(() => dispatch);
-    useSelector.mockImplementation((selector) => selector(dummyLetter));
     jest.useFakeTimers().setSystemTime(new Date('2022-05-20T06:10:16.000+00:00'));
   });
 
-  it('열람가능한 편지', () => {
-    render((<LetterList openLetter />));
-    expect(screen.getByText('오픈된 편지')).toBeInTheDocument();
+  it('열람가능한 편지', async () => {
+    render(<LetterList openLetter />, { initialState: dummyLetter });
+    expect(await screen.findByText('오픈된 편지')).toBeInTheDocument();
   });
   it('열람불가능한 편지', () => {
-    render((<LetterList closeLetter />));
+    render((<LetterList closeLetter />), { initialState: dummyLetter });
     expect(screen.getByText('오픈되지 않은 편지')).toBeInTheDocument();
   });
   it('모든편지', () => {
-    render((<LetterList allLetter />));
+    render((<LetterList allLetter />), { initialState: dummyLetter });
     expect(screen.getByText('오픈된 편지')).toBeInTheDocument();
     expect(screen.getByText('오픈되지 않은 편지')).toBeInTheDocument();
   });

--- a/front/test.utils.js
+++ b/front/test.utils.js
@@ -1,16 +1,37 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import store from './src/store';
+import { LoginApi } from './src/service/login';
+import { LetterApi } from './src/service/Letter';
+import auth from './src/store/auth';
+import letter from './src/store/letter';
+import global from './src/store/global';
 
-function AllTheProviders({ children }) {
-  return (
-    <div>
-      {children}
-    </div>
-  );
-}
-
-const customRender = (ui, options) => render(ui, { wrapper: AllTheProviders, ...options });
+const customRender = (ui, {
+  initialState = {},
+  customStore = configureStore({
+    preloadedState: initialState,
+    reducer: {
+      [LoginApi.reducerPath]: LoginApi.reducer,
+      [LetterApi.reducerPath]: LetterApi.reducer,
+      auth,
+      letter,
+      global,
+    },
+  }),
+} = {}, options) => {
+  function AllTheProviders({ children }) {
+    return (
+      <Provider store={customStore}>
+        {children}
+      </Provider>
+    );
+  }
+  return render(ui, { wrapper: AllTheProviders, ...options });
+};
 
 // re-export everything
 export * from '@testing-library/react';


### PR DESCRIPTION
## 관련이슈
close #65 

## 변경내용
기존의 방법은 redux 관련함수 useSelect dispatch를 mock하는 방법으로 사용했는데 
api 도입시 endpoint까지 일일히 mock + query mutation또한 mock해야하는 번거러움이 있어 msw로 변경하였습니다

msw로 사용시 API 요청이 있을때 가로채서 mock을 한 후 가짜 res를 넘겨 줄 수 있어 다른 mock없이 logic을 그대로 사용해서 테스트해볼수 있는 장점이 있습니다.




### customRender 사용 관련 링크
- https://matan.io/posts/custom-rendering-rtl
