### PR TITLE
test: LetterDetail 테스트 코드 작성

### DIFF
--- a/front/src/__mocks__/Letter.js
+++ b/front/src/__mocks__/Letter.js
@@ -1,6 +1,7 @@
 import { rest } from 'msw';
 
 const date = new Date('2022-04-04T23:50:00');
+const baseURL = 'http://timemachineletter.tk:8080/';
 const dummy = {
   readable: true,
   id: 3,
@@ -8,9 +9,10 @@ const dummy = {
   openAt: date,
   title: '제목1',
   content: '첫번째 테스트 본문입니다',
-  from: '개발자',
-  to: '뭐',
+  letterFrom: '개발자',
+  letterTo: '뭐',
 };
 export const Letter = [
-  rest.get('http://timemachineletter.tk:8080/letter/:hash', (req, res, ctx) => res(ctx.status(200), ctx.json(dummy))),
+  rest.get(`${baseURL}letter/:hash`, (req, res, ctx) => res(ctx.status(200), ctx.json(dummy))),
+  rest.delete(`${baseURL}letter/:hash`, (req, res, ctx) => res(ctx.status(200))),
 ];

--- a/front/src/__test__/components/LetterDetail.test.js
+++ b/front/src/__test__/components/LetterDetail.test.js
@@ -1,0 +1,54 @@
+import { rest } from 'msw';
+import { render, screen, fireEvent, waitFor } from '../../../test.utils';
+import LetterDetail from '../../components/LetterDetail';
+import { server } from '../../__mocks__/server';
+
+describe('LetterDetail 테스트 코드', () => {
+  it('dummy 데이터를 받아 컴포넌트에 보여준다', async () => {
+    render(<LetterDetail />, {
+      initialState: {
+        global: {
+          detailModal: true,
+          LetterHash: 'sodihfgiu9oah894r3hjiohwsrfoi',
+        },
+      },
+    });
+    screen.findByText('발신자:');
+    await screen.findByText('발신자: 개발자');
+    await screen.findByText('수신자: 뭐');
+    await screen.findByText('첫번째 테스트 본문입니다');
+    await screen.findByText('제목1');
+  });
+  it('삭제버튼을 클릭했을때 삭제에 성공한다', async () => {
+    render(<LetterDetail />, {
+      initialState: {
+        global: {
+          detailModal: true,
+          LetterHash: 'sodihfgiu9oah894r3hjiohwsrfoi',
+        },
+      },
+    });
+    jest.spyOn(window, 'alert').mockImplementation(() => {});
+    const deleteButton = screen.getByText('삭제');
+    fireEvent.click(deleteButton);
+    await waitFor(() => expect(window.alert).toBeCalledWith('삭제되었습니다'));
+  });
+  it('삭제 버튼을 클릭했을때 삭제에 실패한다', async () => {
+    render(<LetterDetail />, {
+      initialState: {
+        global: {
+          detailModal: true,
+          LetterHash: 'sodihfgiu9oah894r3hjiohwsrfoi',
+        },
+      },
+    });
+    const baseURL = 'http://timemachineletter.tk:8080/';
+    server.use(
+      rest.delete(`${baseURL}letter/:hash`, (req, res, ctx) => res(ctx.status(400))),
+    );
+    jest.spyOn(window, 'alert').mockImplementation(() => {});
+    const deleteButton = screen.getByText('삭제');
+    fireEvent.click(deleteButton);
+    await waitFor(() => expect(window.alert).toBeCalledWith('삭제에 실패하였습니다'));
+  });
+});

--- a/front/src/__test__/components/LetterDetail.test.js
+++ b/front/src/__test__/components/LetterDetail.test.js
@@ -13,11 +13,12 @@ describe('LetterDetail 테스트 코드', () => {
         },
       },
     });
-    screen.findByText('발신자:');
-    await screen.findByText('발신자: 개발자');
-    await screen.findByText('수신자: 뭐');
-    await screen.findByText('첫번째 테스트 본문입니다');
-    await screen.findByText('제목1');
+
+    expect(screen.getByText('발신자:')).toBeInTheDocument();
+    expect(await screen.findByText('발신자: 개발자')).toBeInTheDocument();
+    expect(await screen.findByText('수신자: 뭐')).toBeInTheDocument();
+    expect(await screen.findByText('첫번째 테스트 본문입니다')).toBeInTheDocument();
+    expect(await screen.findByText('제목1')).toBeInTheDocument();
   });
   it('삭제버튼을 클릭했을때 삭제에 성공한다', async () => {
     render(<LetterDetail />, {


### PR DESCRIPTION
## 관련 이슈
close #65 

## 예상 리뷰 시간
~5min

## 변경사항

-  예전에 API에서 res 중에 from 과 to 를 letterFrom 과 letterTo로 이름이 변경이 있었는데 테스트 코드상에서는 이름이 안바뀌었습니다 따라서 dummyData에 있는 이름을 변경하였습니다
- LetterDetail 코드를 작성하였습니다 랜더링여부, 메세지 삭제시에 성공 실패, 케이스 3개로 나누었습니다. 

## 스크린샷
![image](https://user-images.githubusercontent.com/49224104/174020614-c85cf5ad-0f02-40f8-8251-b2cc3af5e94e.png)


## 당부할말
@kangju2000  baseUrl을 따로 빼는 작업이 있었으면 좋겠습니다 하던 결과물 완성되면 추출하는 작업을 진행해보도록 하겠습니다 #73

